### PR TITLE
Allow to cache 204 responses

### DIFF
--- a/lib/faraday/http_cache/response.rb
+++ b/lib/faraday/http_cache/response.rb
@@ -17,7 +17,7 @@ module Faraday
       # * 302 - 'Found'
       # * 404 - 'Not Found'
       # * 410 - 'Gone'
-      CACHEABLE_STATUS_CODES = [200, 203, 300, 301, 302, 307, 404, 410].freeze
+      CACHEABLE_STATUS_CODES = [200, 203, 204, 300, 301, 302, 307, 404, 410].freeze
 
       # Internal: Gets the actual response Hash (status, headers and body).
       attr_reader :payload


### PR DESCRIPTION
Hi,

Any reason why we do not cache 204 responses?

Should this list be made configurable instead?
